### PR TITLE
Two consecutive bond descriptors

### DIFF
--- a/src/gbigsmiles/exception.py
+++ b/src/gbigsmiles/exception.py
@@ -98,7 +98,7 @@ class TwoConsecutiveBondDescriptors(ParsingError):
         self.stochastic_obj = stochastic_obj
 
     def __str__(self):
-        return f"The object {self.obj} in stochastic object {self.stochastic_obj} has two consecutive bond descriptors which is forbidden by BigSmiles grammar."  
+        return f"The object {self.obj} in stochastic object {self.stochastic_obj} has two consecutive bond descriptors which is forbidden by BigSmiles grammar."
 
 
 class IncorrectNumberOfBondDescriptors(ParsingError):

--- a/src/gbigsmiles/exception.py
+++ b/src/gbigsmiles/exception.py
@@ -92,6 +92,15 @@ class DoubleBondSymbolDefinition(GenerationError):
         return f"{self.partial_graph}, {self.symbol}, {self.bond_attributes}"
 
 
+class TwoConsecutiveBondDescriptors(ParsingError):
+    def __init__(self, obj, stochastic_obj):
+        self.obj = obj
+        self.stochastic_obj = stochastic_obj
+
+    def __str__(self):
+        return f"The object {self.obj} in stochastic object {self.stochastic_obj} has two consecutive bond descriptors which is forbidden by BigSmiles grammar."  
+
+
 class IncorrectNumberOfBondDescriptors(ParsingError):
     def __init__(self, obj, expected_number_of_bond_descriptors):
         self.obj = obj

--- a/src/gbigsmiles/stochastic.py
+++ b/src/gbigsmiles/stochastic.py
@@ -18,6 +18,7 @@ from .exception import (
     NoInitiationForStochasticObject,
     NoLeftTransitions,
     StochasticMissingPath,
+    TwoConsecutiveBondDescriptors    
 )
 from .generating_graph import (
     _STOCHASTIC_NAME,
@@ -83,9 +84,13 @@ class StochasticObject(BigSMILESbase, GenerationBase):
 
     def _post_parse_validation(self):
         for element in self._repeat_residues + self._termination_residues:
-            gengraph = element.GeneratingGraph()
-            "iterate over nodes that are bd and check if they're connected to other bd"
-            raise TwoConsecutiveBondDescriptors(...)
+            gengraph = element.get_generating_graph()
+            for node in gengraph.g.nodes():
+
+                if node in gengraph._bd_idx_set:
+                    for _u, v in gengraph.g.out_edges(node):
+                        if v in gengraph._bd_idx_set:
+                            raise TwoConsecutiveBondDescriptors(element, self)
 
         for smi in self._repeat_residues:
             if len(smi.bond_descriptors) < 2:

--- a/src/gbigsmiles/stochastic.py
+++ b/src/gbigsmiles/stochastic.py
@@ -82,6 +82,11 @@ class StochasticObject(BigSMILESbase, GenerationBase):
         self._stochastic_parent = parent
 
     def _post_parse_validation(self):
+        for element in self._repeat_residues + self._termination_residues:
+            gengraph = element.GeneratingGraph()
+            "iterate over nodes that are bd and check if they're connected to other bd"
+            raise TwoConsecutiveBondDescriptors(...)
+
         for smi in self._repeat_residues:
             if len(smi.bond_descriptors) < 2:
                 raise MonomerHasTwoOrMoreBondDescriptors(smi, self)

--- a/src/gbigsmiles/stochastic.py
+++ b/src/gbigsmiles/stochastic.py
@@ -18,7 +18,7 @@ from .exception import (
     NoInitiationForStochasticObject,
     NoLeftTransitions,
     StochasticMissingPath,
-    TwoConsecutiveBondDescriptors    
+    TwoConsecutiveBondDescriptors,
 )
 from .generating_graph import (
     _STOCHASTIC_NAME,

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -36,6 +36,22 @@ invalid_monomer_stochastic = [
     "{[<] [>]CC, [<]C([$])C[>]; [$]Br [>]}",
 ]
 
+invalid_bond_descriptor_sequence = [
+    "{[] [>]CC[>][<] []}",
+    "{[] [<]N(CC[>][<])N[>], [>]CC[<]; [$][H], [<]Br []}",
+    "{[<] [<]NN[>], [$]CC[$][$]; [$][H], [<]Br [>]}",
+    "{[<] [<]NN[>], [>]CC[<]; [$][$][H], [<]Br [>]}",
+]
+
+
+@pytest.mark.parametrize("stochastic_smi", invalid_bond_descriptor_sequence)
+def test_bond_descriptor_sequence(stochastic_smi):
+    with pytest.raises(gbigsmiles.exception.TwoConsecutiveBondDescriptors):
+        try:
+            gbigsmiles.StochasticObject.make(stochastic_smi)
+        except lark.exceptions.VisitError as exc:
+            raise exc.__context__  # trunk-ignore(ruff/B904)
+
 
 @pytest.mark.parametrize("stochastic_smi", invalid_monomer_stochastic)
 def test_invalid_monomer_stochastic(stochastic_smi):


### PR DESCRIPTION
I added an exception to prevent stochastic objects from having two consecutive bond descriptors. This PR is intended to solve the issue that reports the absence of this exception. 